### PR TITLE
fix(cicd) push temp image and use it with Trivy + use code-server tag from Dockerfile.

### DIFF
--- a/.github/workflows/generic-docker-build.yml
+++ b/.github/workflows/generic-docker-build.yml
@@ -25,7 +25,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build:
+  build-scan-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +33,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Build informations
+        id: build-info
+        run: |
+          echo "Building ${{ inputs.image-name || inputs.image-folder }} (tag ${{ inputs.image-tag }})"
+          echo "ci-image-name=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name || inputs.image-folder }}:ci-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "image-name=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name || inputs.image-folder }}:${{ inputs.image-tag }}" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v5
 
@@ -49,28 +56,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image
+      - name: Build and push temporary ci Docker image
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ inputs.image-folder }}
-          push: ${{ github.ref == 'refs/heads/main' }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name || inputs.image-folder }}:${{ inputs.image-tag }}
+          push: true
+          tags: ${{ steps.build-info.outputs.ci-image-name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    needs: build
-    steps:
-      - uses: actions/checkout@v5
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name || inputs.image-folder }}:${{ inputs.image-tag }}
+          image-ref: ${{ steps.build-info.outputs.ci-image-name }}
           format: "table"
           exit-code: "1"
           ignore-unfixed: true
@@ -81,6 +80,16 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker image after trivy scan
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ inputs.image-folder }}
+          tags: ${{ steps.build-info.outputs.image-name }}
+          push: ${{ github.ref == 'refs/heads/main' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   lint:
     runs-on: ubuntu-latest

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -17,7 +17,7 @@ FROM ghcr.io/opentofu/opentofu:1.10.6-minimal AS opentofu
 FROM docker.io/hashicorp/terraform:1.13.2 AS terraform
 FROM registry.gitlab.com/gitlab-org/cli:v1.68.0 AS gitlab-cli
 
-FROM ghcr.io/coder/code-server:4.101.2-noble
+FROM ghcr.io/coder/code-server:4.103.2-noble
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Currently, Trivy is using image tags but if we are not build main branch, the image is not pushed.

This PR change the build behaviour: 
- Build an image an push it with ci tags
- Run trivy
- Promote image if scan is ok and target branch is main
- Remove ci image