### PR TITLE
fix(code-server): utiliser des UID numériques pour satisfaire hadolint DL3066

### DIFF
--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -22,8 +22,8 @@ FROM ghcr.io/coder/code-server:4.130.0-noble
 ARG TARGETOS
 ARG TARGETARCH
 
-# Nécessaire pour installer les paquets
-USER root
+# Nécessaire pour installer les paquets (UID numérique = root, requis par hadolint DL3066)
+USER 0
 WORKDIR /home/coder
 ENV DEBIAN_FRONTEND=noninteractive TZ=Europe/Paris
 # Mettre à jour les paquets et installer les dépendances
@@ -81,8 +81,8 @@ RUN set -eux; \
     install -m 0755 /tmp/claude /usr/local/bin/claude; \
     rm -f /tmp/claude
 
-# Et on revient à un utilisateur lambda pour la suite
-USER coder
+# Et on revient à un utilisateur lambda pour la suite (UID numérique = coder, requis par hadolint DL3066)
+USER 1000
 
 # Install AWS CLI & docker-credential-ecr-login
 COPY --from=aws-cli /usr/local /usr/local


### PR DESCRIPTION
## Summary
- Le bump `hadolint-action` 3.3.0 → 3.4.0 (#761) embarque hadolint 2.15, qui introduit la règle **DL3066** (« Non-numeric user-id may not be resolvable by host system »). L'action utilisant `failure-threshold: info` par défaut, `USER root` et `USER coder` dans `code-server/Dockerfile` faisaient échouer le job `lint` sur `main`, bloquant la publication de l'image (job `push` dépend de `needs: [build, scan, lint]`).
- Remplace `USER root` → `USER 0` et `USER coder` → `USER 1000`, comme le fait déjà l'image amont `coder/code-server` (dont le Dockerfile de release se termine par `USER 1000`).

## Test plan
- [x] Reproduit l'échec en local avec hadolint 2.15.0 (version exacte embarquée par hadolint-action@v3.4.0) sur le `Dockerfile` avant correction : 2x DL3066, exit code 1.
- [x] Même commande sur le `Dockerfile` corrigé : aucune sortie, exit code 0.
- [x] Vérifié que les 3 autres Dockerfiles du repo (`bats`, `download-api`, `j2cli`) ne contiennent aucune instruction `USER` et ne sont donc pas concernés.
- [x] CI (`build-code-server / lint`, `build`, `scan`) à vérifier verte sur cette PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014jCkQ3XSp2RvhRE6rSmYyA)_